### PR TITLE
[PR relay] dotnet/wpf#11124: Pass the HwndSource parameters directly

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Input/Stylus/Wisp/WispLogic.cs
@@ -3124,10 +3124,8 @@ namespace System.Windows.Input.StylusWisp
         }
 
         /////////////////////////////////////////////////////////////////////
-        internal void RegisterHwndForInput(InputManager inputManager, PresentationSource inputSource)
+        internal void RegisterHwndForInput(InputManager inputManager, HwndSource hwndSource)
         {
-            HwndSource hwndSource = (HwndSource)inputSource;
-
             GetAndCacheTransformToDeviceMatrix(hwndSource);
 
             // Keep track so we don't bother looking for changes if someone happened to query this before
@@ -3139,14 +3137,14 @@ namespace System.Windows.Input.StylusWisp
 
             lock (__penContextsLock)
             {
-                if (__penContextsMap.ContainsKey(inputSource))
+                if (__penContextsMap.ContainsKey(hwndSource))
                 {
                     throw new InvalidOperationException(SR.PenService_WindowAlreadyRegistered);
                 }
 
-                PenContexts penContexts = new PenContexts(StylusLogic.GetCurrentStylusLogicAs<WispLogic>(), inputSource);
+                PenContexts penContexts = new PenContexts(StylusLogic.GetCurrentStylusLogicAs<WispLogic>(), hwndSource);
 
-                __penContextsMap[inputSource] = penContexts;
+                __penContextsMap[hwndSource] = penContexts;
 
                 // If FIRST one set this as the one to manage TabletAdded/Removed notifications.
                 if (__penContextsMap.Count == 1)


### PR DESCRIPTION
Relays https://github.com/dotnet/wpf/pull/11124.

- Source base: `dotnet/wpf:main` at `ee7cbb82652173e3a9f4e8feec155eb58eed5f4f`
- Source head: `dotnet-campus/wpf:t/lindexi/RegisterHwndForInput` at `6e23ef8c4d4a5c10d7cadeda53290dc2d0020148`
- Target: `WpfLab/WpfRuntime:main` <- `t/bot/PR_11124`
- Local validation skipped; GitHub Actions is responsible for validation.
- GitHub Actions build results will be written back by the trusted metadata workflow.

Source-PR: https://github.com/dotnet/wpf/pull/11124
Source-Head-SHA: 6e23ef8c4d4a5c10d7cadeda53290dc2d0020148

<!-- builder-pr-relay source=dotnet/wpf#11124 -->