### PR TITLE
[PR relay] dotnet/wpf#11816: Fix Nullable<T> detection inside MetadataLoadContext to emit proper BamlRecordType

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
+++ b/src/Microsoft.DotNet.Wpf/src/Shared/System/Windows/Markup/ReflectionHelper.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -122,7 +122,14 @@ namespace System.Xaml
 
         internal static bool IsNullableType(Type type)
         {
-            return (type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(Nullable<>)));
+#if NET11_0_OR_GREATER
+            return type.GetNullableUnderlyingType() is not null;
+#else
+            Type nullableType = _metadataLoadContext.CoreAssembly?.GetType("System.Nullable`1");
+            Debug.Assert(nullableType is not null, "System.Nullable`1 type not found in MetadataLoadContext");
+
+            return type.IsGenericType && nullableType == type.GetGenericTypeDefinition();
+#endif
         }
 
         internal static bool IsInternalType(Type type)


### PR DESCRIPTION
Relays https://github.com/dotnet/wpf/pull/11816.

- Source base: `dotnet/wpf:main` at `2ca037562c207924e53cfcc99286e523d3694de3`
- Source head: `h3xds1nz/wpf:fix-nullable-on-net-11` at `9c05eaaa32bff05c00d6819f885b9eed47c4da64`
- Target: `WpfLab/WpfRuntime:main` <- `t/bot/PR_11816`
- Local validation skipped; GitHub Actions is responsible for validation.
- GitHub Actions build results will be written back by the trusted metadata workflow.

Source-PR: https://github.com/dotnet/wpf/pull/11816
Source-Head-SHA: 9c05eaaa32bff05c00d6819f885b9eed47c4da64

<!-- builder-pr-relay source=dotnet/wpf#11816 -->