### PR TITLE
Revert "Add trusted publishing"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,6 @@ jobs:
       actions: read
       contents: read
       packages: write
-      id-token: write  # enable GitHub OIDC token issuance for this job
 
     steps:
     - name: Download NuGet package artifact
@@ -158,14 +157,6 @@ jobs:
         name: ${{ needs.build-package.outputs.artifact-name }}-symbols
         path: nupkg
 
-    # Get a short-lived NuGet API key
-    - name: NuGet login (OIDC → temp API key)
-      uses: NuGet/login@v1
-      id: login
-      with:
-        user: lindexi # Recommended: use a secret like ${{ secrets.NUGET_USER }} for your nuget.org username (profile name), NOT your email address
-    
-
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v6
       with:
@@ -178,5 +169,5 @@ jobs:
         if (-not (Test-Path -LiteralPath $packagePath -PathType Leaf)) {
           throw "Expected NuGet package was not found: $packagePath"
         }
-        dotnet nuget push $packagePath -s https://api.nuget.org/v3/index.json -api-key ${{steps.login.outputs.NUGET_API_KEY}}
+        dotnet nuget push $packagePath -s https://api.nuget.org/v3/index.json -k "${{ secrets.NugetKey }}"
         dotnet nuget push $packagePath -s "https://nuget.pkg.github.com/${{ github.repository_owner }}" --api-key "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
We need any dev to be able to push NuGet packages, so we can't really lock this down. Plus, the current config just spits out cryptic errors that nobody can make sense of.

```
Run NuGet/login@v1
  with:
    user: lindexi
    token-service-url: https://www.nuget.org/api/v2/token
    audience: https://www.nuget.org/
Error: Token exchange failed (HTTP 401) at https://www.nuget.org/api/v2/token. Make sure you are using the username of the policy creator, not the policy owner: The GitHub Actions event 'pull_request_target' is not allowed.
```

https://github.com/WpfLab/WpfRuntime/actions/runs/31138716973/job/92746849930